### PR TITLE
Improve Cohere tokenizer tests

### DIFF
--- a/src/canopy/tokenizer/cohere.py
+++ b/src/canopy/tokenizer/cohere.py
@@ -49,7 +49,7 @@ class CohereHFTokenizer(BaseTokenizer):
         Returns:
             The list of tokens.
         """
-        return self._encoder.encode(text).tokens
+        return self._encoder.encode(text, add_special_tokens=False).tokens
 
     def detokenize(self, tokens: List[str]) -> str:
         """
@@ -77,7 +77,7 @@ class CohereHFTokenizer(BaseTokenizer):
         Returns:
             The number of tokens in the text.
         """
-        return len(self._encoder.encode(text).ids)
+        return len(self._encoder.encode(text, add_special_tokens=False).ids)
 
     def messages_token_count(self, messages: Messages) -> int:
         """

--- a/tests/system/tokenizer/test_cohere_api_tokenizer.py
+++ b/tests/system/tokenizer/test_cohere_api_tokenizer.py
@@ -11,7 +11,7 @@ class TestCohereAPITokenizer(BaseTestTokenizer):
     @staticmethod
     @pytest.fixture(scope="class")
     def tokenizer():
-        if not os.getenv("Co_API_KEY"):
+        if not os.getenv("CO_API_KEY"):
             pytest.skip("Skipping Cohere API tokenizer tests because "
                         "COHERE_API_KEY environment variable is not set.")
         return CohereAPITokenizer(model_name="command")

--- a/tests/unit/tokenizer/test_cohere_hf_tokenizer.py
+++ b/tests/unit/tokenizer/test_cohere_hf_tokenizer.py
@@ -14,7 +14,6 @@ class TestCohereHFTokenizer(BaseTestTokenizer):
     @pytest.fixture
     def expected_tokens(text):
         return [
-            '<BOS_TOKEN>',
             'string',
             'Ġwith',
             'Ġspecial',
@@ -44,29 +43,12 @@ class TestCohereHFTokenizer(BaseTestTokenizer):
             'A',
             'se',
             'Ġ',
-            '<EOP_TOKEN>'
         ]
-
-    @staticmethod
-    def test_tokenize_empty_string(tokenizer):
-        """
-        Overrides test from base class because Cohere considers that
-        an empty string has two tokens, not zero.
-        """
-        assert tokenizer.tokenize("") == ['<BOS_TOKEN>', '<EOP_TOKEN>']
-
-    @staticmethod
-    def test_token_count_empty_string(tokenizer):
-        """
-        Overrides test from base class because Cohere considers that
-        an empty string has two tokens, not zero.
-        """
-        assert tokenizer.token_count("") == 2
 
     @staticmethod
     def test_messages_token_count(tokenizer):
         messages = [MessageBase(role=Role.USER, content="Hello, assistant.")]
-        assert tokenizer.messages_token_count(messages) == 15
+        assert tokenizer.messages_token_count(messages) == 11
 
         messages = [
             MessageBase(role=Role.USER, content="Hello, assistant."),
@@ -74,38 +56,13 @@ class TestCohereHFTokenizer(BaseTestTokenizer):
                 role=Role.ASSISTANT, content="Hello, user. How can I assist you?"
             ),
         ]
-        assert tokenizer.messages_token_count(messages) == 33
-
-    @staticmethod
-    def test_messages_token_count_empty_messages(tokenizer):
-        assert tokenizer.messages_token_count([]) == 3
+        assert tokenizer.messages_token_count(messages) == 25
 
     @staticmethod
     def test_special_tokens_to_natural_text(tokenizer):
-        input_text = "</s>_<0x0A>__ <unk><s>word"
-        tokens = tokenizer.tokenize(input_text)
+        tokens = tokenizer.tokenize("<BOS_TOKEN>")
+        assert tokens == ['<', 'BOS', '_', 'TOKEN', '>']
 
-        expected_tokens = [
-            '<BOS_TOKEN>',
-            '</',
-            's',
-            '>',
-            '_<',
-            '0',
-            'x',
-            '0',
-            'A',
-            '>',
-            '__',
-            'Ġ<',
-            'unk',
-            '><',
-            's',
-            '>',
-            'word',
-            '<EOP_TOKEN>',
-        ]
+        assert tokenizer.detokenize(tokens) == "<BOS_TOKEN>"
 
-        assert tokens == expected_tokens
-        assert tokenizer.detokenize(tokens) == input_text
-        assert tokenizer.token_count(input_text) == len(tokens)
+        assert tokenizer.token_count("<BOS_TOKEN>") == 5


### PR DESCRIPTION
Hi @scottmx81,

Thank you very much for your efforts on https://github.com/pinecone-io/canopy/pull/204!!! Your dedication is far beyond expectation! 

I took the liberty to suggest a few minor tweaks to your Tokenizer testing:
1. I changed `TestCohereAPITokenizer` to inherit `BaseTestTokenizer`, making the test more thorough and with less duplication.
2. I slightly changed the behavior of `CohereTokenizer`, making it drop the (<BOS_TOKEN>`, `<EOP_TOKEN>`) special tokens. This way it resembles the API tokenizer better - which hopefully makes it more accurate approximation.

